### PR TITLE
Fixing bug with Ruby 3 keyword arguments.

### DIFF
--- a/lib/site_prism/rspec_matchers.rb
+++ b/lib/site_prism/rspec_matchers.rb
@@ -19,14 +19,27 @@ module SitePrism
     private
 
     def create_rspec_existence_matchers(matcher, object_method, negated_object_method, warning)
-      RSpec::Matchers.define(matcher) do |*args|
-        match { |actual| actual.public_send(object_method, *args) }
+      forward = forwarder(object_method)
+
+      RSpec::Matchers.define(matcher) do |*args, **options|
+        match { |actual| forward.call(actual, args, options) }
         match_when_negated do |actual|
-          return actual.public_send(negated_object_method, *args) if actual.respond_to?(negated_object_method)
+          return forward.call(actual, args, options, negated_object_method) if actual.respond_to?(negated_object_method)
 
           SitePrism.logger.debug(warning)
-          !actual.public_send(object_method, *args)
+          !forward.call(actual, args, options)
         end
+      end
+    end
+
+    def forwarder(object_method)
+      lambda do |actual, args, options, method_name = object_method|
+        # To support Ruby 2.6. Otherwise methods that expect no arguments would fail with
+        # "wrong number of arguments (given 1, expected 0)" because Ruby 2.6 considers `method(**{})` the
+        # same as `method({})` (passing the empty Hash as an argument)
+        next actual.public_send(method_name, *args) if options.empty?
+
+        actual.public_send(method_name, *args, **options)
       end
     end
 

--- a/spec/site_prism/rspec_matchers_spec.rb
+++ b/spec/site_prism/rspec_matchers_spec.rb
@@ -1,0 +1,38 @@
+# frozen_string_literal: true
+
+class CapybaraOverridingPage < SitePrism::Page
+  # Creating some elements that will cause SitePrism to override the default `has_link?` and `has_table?`
+  # matchers from Capybara
+  element :link, 'a'
+  element :table, 'table'
+end
+
+describe SitePrism::RspecMatchers do
+  include Capybara::DSL
+
+  around do |example|
+    app = Capybara.app
+
+    begin
+      Capybara.app = ->(_env) { [200, {}, <<-HTML] }
+        <html><head></head><body><a href="#">a</a><table id="my-table"></table></body></html>
+      HTML
+
+      example.run
+    ensure
+      Capybara.app = app
+    end
+  end
+
+  it 'works with Ruby 3 keyword arguments for links' do
+    visit '/'
+
+    expect(page).to have_link('a', href: '#')
+  end
+
+  it 'works with Ruby 3 keyword arguments for tables' do
+    visit '/'
+
+    expect(page).to have_table('my-table', rows: [])
+  end
+end


### PR DESCRIPTION
Without this fix, we get "wrong number of arguments (given 2, expected 0..1)".